### PR TITLE
Explicitly read from `/dev/tty`

### DIFF
--- a/examples/kitty/main.rs
+++ b/examples/kitty/main.rs
@@ -1,4 +1,3 @@
-
 /// In order to query, go to raw mode, query the terminal, then leave raw mode.
 ///
 /// This example uses crossterm because I'm used to it but you may use other
@@ -30,4 +29,3 @@ pub fn main() {
     }
     println!("Operation took {:?}", start.elapsed());
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-
 /// xterm-query error type
 #[derive(thiserror::Error, Debug)]
 pub enum XQError {
@@ -18,5 +17,3 @@ pub enum XQError {
     #[error("Unsupported platform")]
     Unsupported,
 }
-
-


### PR DESCRIPTION
We can not assume that stdin is a tty. This assumption can break very easily for the using application, e.g if the stdin is piped (which is not even in the control of the application developer but users).
