### PR TITLE
Use polling syscall directly to fix MacOS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ readme = "README.md"
 thiserror = "1.0"
 
 [target.'cfg(unix)'.dependencies]
-mio = { version = "0.8", features = ["os-ext"] }
-nix = "0.22"
+nix = { version = "0.28", features = ["poll"] }
 
 [dev-dependencies]
 crossterm = "0.21"


### PR DESCRIPTION
On MacOS, `poll` and `kqueue` are not supported for tty[1]. So let's ditch mio completely and directly call `select` ourselves.

On non-MacOS, we use `poll` to avoid limitation of `select` that is limited to FDs below 1024. If the process has a lot of open FDs, we could end up with an FD higher than 1023 and get an error.

This fixes MacOS support.

[1]: https://github.com/tokio-rs/mio/issues/1377

Fixes #3.

---

This replaces #2.