### PR TITLE
Update to nix 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 thiserror = "1.0"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.28", features = ["poll"] }
+nix = { version = "0.29", features = ["poll"] }
 
 [dev-dependencies]
 crossterm = "0.21"


### PR DESCRIPTION
This will allow my dependent crate, gimoji to depend on a single version of nix when I upgrade there.