### PR TITLE
Use a Status Report command to detect when an OSC is not supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
         os::fd::AsFd,
     };
     const ESC: char = '\x1b';
+    const BEL: char = '\x07';
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
@@ -123,7 +124,7 @@ pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
                             }
                         }
                         Some(start_idx) => {
-                            if b == ESC as u8 || b == /* BEL */ 7 {
+                            if b == ESC as u8 || b == BEL as u8 {
                                 if osc_end_idx.is_none() {
                                     osc_end_idx = Some(i);
                                 }


### PR DESCRIPTION
The idea (from my coworker @mmastrac) is that if a terminal doesn't implement the OSC being queried, it will ignore it but still respond to the CSR Status Report command, and so we can detect it not being supported. 

This will give clients the freedom to use much larger timeouts, since we expect the fence to catch terminals that do not support it.

The motivation here is that with the 100ms timeout that `terminal-light` uses, it is not that hard to hit the timeout over a slow SSH connection. If we can detect the sequence not being supported, then we can feel better about increasing the timeout substantially.

If this PR is accepted, I have follow-up PRs that I'll submit to `terminal_light` to update the documentation of the technique used and to allow configuring timeouts:
* https://github.com/msullivan/terminal-light/pull/1
* https://github.com/msullivan/terminal-light/pull/2