### PR TITLE
Correct select call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,11 +78,10 @@ fn wait_for_input<MS: Into<u64>>(fd: BorrowedFd<'_>, timeout_ms: MS) -> Result<i
     };
     let mut fd_set = FdSet::new();
     fd_set.insert(fd);
-    let timeout_us = Duration::from_millis(timeout_ms.into())
-        .as_micros()
-        .try_into()
-        .map_err(|_| Errno::EOVERFLOW)?;
-    let mut tv = TimeVal::new(0, timeout_us);
+    let mut dur =  Duration::from_millis(timeout_ms.into());
+    let timeout_s = dur.as_secs() as _;
+    let timeout_us = dur.subsec_micros() as _;
+    let mut tv = TimeVal::new(timeout_s, timeout_us);
 
     select(
         fd.as_raw_fd() + 1,


### PR DESCRIPTION
Fixes #8

The duration needs to be correctly unpacked into seconds + useconds to avoid `EINVAL` on macos.

Tested locally using the Gel fork of `terminal_light` -- before this patch we would get EINVAL and fail to read the RGB OSC request. After this patch, the OSC request is correctly read.