### PR TITLE
feat: add Windows backend (CONIN\$ + WaitForSingleObject)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/xterm-query"
 description = "query your terminal"
-keywords = ["terminal", "xterm", "query", "unix"]
+keywords = ["terminal", "xterm", "query", "unix", "windows"]
 license = "MIT"
 categories = ["command-line-interface"]
 readme = "README.md"
@@ -15,6 +15,16 @@ thiserror = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["poll"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Console",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+    "Win32_Storage_FileSystem",
+] }
 
 [dev-dependencies]
 crossterm = "0.21"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Low level library to query the terminal with a CSI sequence and get the result a
 Notes:
 
 - the terminal must already be in raw mode
-- there's no Windows support (it should be possible with [WSAPoll](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll) but I don't have any Windows computer to test so a PR would be welcome)
+- the query should be issued while nothing else is reading terminal input
+- Windows is supported, reading the reply from the console input (`CONIN$`) after switching it to `ENABLE_VIRTUAL_TERMINAL_INPUT` for the duration of the query. Caveat: the Windows wait can wake on non-character console events (focus, mouse, buffer-resize), so a reply may occasionally be wrong or empty — treat an unparsable reply as "unsupported", and issue queries while the terminal is quiet (e.g. at startup)
 
 The provided example in examples/kitty demonstrates querying the terminal to know whether the [Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/) is supported, and manages entering and leaving raw mode.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,12 @@ pub(crate) fn scan_osc(buf: &[u8]) -> OscScan {
             Some(start) => {
                 if osc_end.is_none() && (b == ESC || b == BEL) {
                     osc_end = Some(i);
-                } else if b == b'n' {
+                } else if i >= 3
+                    && buf[i - 3] == ESC
+                    && buf[i - 2] == b'['
+                    && buf[i - 1] == b'0'
+                    && b == b'n'
+                {
                     return match osc_end {
                         None => OscScan::NotOsc,
                         Some(end) => OscScan::Found {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,31 @@
+//! Query the terminal by writing an escape sequence and reading the reply.
+//!
+//! The terminal must be in raw mode (otherwise reads block on a newline), and
+//! the query should be issued when nothing else is reading terminal input.
+//!
+//! # Platform support
+//!
+//! Unix reads the reply from `/dev/tty` using `poll`/`select`. Windows reads it
+//! from the console input (`CONIN$`) after switching it to
+//! `ENABLE_VIRTUAL_TERMINAL_INPUT` for the duration of the query.
+//!
+//! ## Windows limitation
+//!
+//! The Windows wait wakes on any console input event, including focus, mouse,
+//! and buffer-resize events, which under VT-input mode may be delivered as
+//! escape sequences. If such an event arrives in the query window, the reply
+//! can be wrong or empty, so callers should treat an unparsable reply as
+//! "unsupported" and degrade gracefully. Issue queries while the terminal is
+//! otherwise quiet (e.g. at startup, before an input loop begins).
+
 mod error;
 
-use {nix::errno::Errno, std::os::fd::BorrowedFd};
-
 pub use error::*;
+
+#[cfg(windows)]
+mod win;
+#[cfg(windows)]
+pub use win::{query_buffer, query_osc_buffer};
 
 /// Query the xterm interface, assuming the terminal is in raw mode
 /// (or we would block waiting for a newline).
@@ -32,6 +55,59 @@ pub fn query_osc<MS: Into<u64>>(query: &str, timeout_ms: MS) -> Result<String, X
     let s = std::str::from_utf8(resp)?;
     Ok(s.to_string())
 }
+
+/// Outcome of scanning a (partial) buffer for an OSC response framed as
+/// `ESC ... (ESC|BEL)`, followed by the `n` of the DSR ("fence") reply.
+///
+/// The fence (`ESC[5n` -> `ESC[0n`) lets us detect terminals that don't
+/// support the query: they answer the Status Report first, so we meet the
+/// `n` before ever seeing a complete OSC.
+pub(crate) enum OscScan {
+    /// Not enough bytes yet; read more.
+    NeedMore,
+    /// A complete OSC response was found. `start`/`end` are byte indices into
+    /// the scanned buffer; the payload is `buf[start..=end]` (the leading ESC
+    /// is excluded, the terminating ESC/BEL is included, matching the
+    /// historical Unix behavior).
+    Found { start: usize, end: usize },
+    /// The fence answered before a complete OSC: not an OSC response.
+    NotOsc,
+}
+
+/// Scan a buffer for an OSC response. Pure and platform-independent so it can
+/// be shared by the Unix and Windows backends and unit-tested anywhere.
+pub(crate) fn scan_osc(buf: &[u8]) -> OscScan {
+    const ESC: u8 = 0x1b;
+    const BEL: u8 = 0x07;
+    let mut osc_start: Option<usize> = None;
+    let mut osc_end: Option<usize> = None;
+    for (i, &b) in buf.iter().enumerate() {
+        match osc_start {
+            None => {
+                if b == ESC {
+                    osc_start = Some(i);
+                }
+            }
+            Some(start) => {
+                if osc_end.is_none() && (b == ESC || b == BEL) {
+                    osc_end = Some(i);
+                } else if b == b'n' {
+                    return match osc_end {
+                        None => OscScan::NotOsc,
+                        Some(end) => OscScan::Found {
+                            start: start + 1,
+                            end,
+                        },
+                    };
+                }
+            }
+        }
+    }
+    OscScan::NeedMore
+}
+
+#[cfg(unix)]
+use {nix::errno::Errno, std::os::fd::BorrowedFd};
 
 /// Query the xterm interface, assuming the terminal is in raw mode
 /// (or we would block waiting for a newline).
@@ -87,7 +163,6 @@ pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
         os::fd::AsFd,
     };
     const ESC: char = '\x1b';
-    const BEL: char = '\x07';
 
     // Do some casing based on the terminal
     let term = std::env::var("TERM").map_err(|_| XQError::Unsupported)?;
@@ -119,47 +194,24 @@ pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
 
     stdout.flush()?;
     let mut stdin = File::open("/dev/tty")?;
-    let mut osc_start_idx = None;
-    let mut osc_end_idx = None;
-    let mut bytes_written = 0;
-    while bytes_written < buffer.len() {
+    let mut filled = 0;
+    while filled < buffer.len() {
         let stdin_fd = stdin.as_fd();
         match wait_for_input(stdin_fd, timeout_ms) {
             Ok(0) => {
                 return Err(XQError::Timeout);
             }
             Ok(_) => {
-                let bytes_read = stdin.read(&mut buffer[bytes_written..])?;
+                let bytes_read = stdin.read(&mut buffer[filled..])?;
                 if bytes_read == 0 {
                     return Err(XQError::NotAnOSCResponse); // EOF
                 }
-                // the sequence must start with a ESC (27) and end either with a ESC or BEL (7)
-                // then, we'll get an 'n' back from the "fence"
-                for i in bytes_written..bytes_written + bytes_read {
-                    let b = buffer[i];
-                    match osc_start_idx {
-                        None => {
-                            if b == ESC as u8 {
-                                osc_start_idx = Some(i);
-                            }
-                        }
-                        Some(start_idx) => {
-                            if b == ESC as u8 || b == BEL as u8 {
-                                if osc_end_idx.is_none() {
-                                    osc_end_idx = Some(i);
-                                }
-                            } else if b == b'n' {
-                                match osc_end_idx {
-                                    None => return Err(XQError::NotAnOSCResponse),
-                                    Some(end_idx) => {
-                                        return Ok(&buffer[start_idx + 1..=end_idx]);
-                                    }
-                                }
-                            }
-                        }
-                    }
+                filled += bytes_read;
+                match scan_osc(&buffer[..filled]) {
+                    OscScan::Found { start, end } => return Ok(&buffer[start..=end]),
+                    OscScan::NotOsc => return Err(XQError::NotAnOSCResponse),
+                    OscScan::NeedMore => {}
                 }
-                bytes_written += bytes_read;
             }
             Err(e) => {
                 return Err(XQError::IO(e.into()));
@@ -169,12 +221,25 @@ pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
     Err(XQError::BufferOverflow)
 }
 
-#[cfg(not(unix))]
-pub fn query_buffer(_query: &str, _buffer: &mut [u8], _timeout_ms: u64) -> Result<usize, XQError> {
+#[cfg(not(any(unix, windows)))]
+pub fn query_buffer<MS: Into<u64>>(
+    _query: &str,
+    _buffer: &mut [u8],
+    _timeout_ms: MS,
+) -> Result<usize, XQError> {
     Err(XQError::Unsupported)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(unix, windows)))]
+pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
+    _query: &str,
+    _buffer: &'b mut [u8],
+    _timeout_ms: MS,
+) -> Result<&'b [u8], XQError> {
+    Err(XQError::Unsupported)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn wait_for_input<MS: Into<u64>>(fd: BorrowedFd<'_>, timeout_ms: MS) -> Result<i32, Errno> {
     use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 
@@ -187,7 +252,7 @@ fn wait_for_input<MS: Into<u64>>(fd: BorrowedFd<'_>, timeout_ms: MS) -> Result<i
 // On MacOS, we need to use the `select` instead of `poll` because it doesn't support poll with tty:
 //
 // https://github.com/tokio-rs/mio/issues/1377
-#[cfg(target_os = "macos")]
+#[cfg(all(unix, target_os = "macos"))]
 fn wait_for_input<MS: Into<u64>>(fd: BorrowedFd<'_>, timeout_ms: MS) -> Result<i32, Errno> {
     use {
         nix::sys::{
@@ -198,7 +263,7 @@ fn wait_for_input<MS: Into<u64>>(fd: BorrowedFd<'_>, timeout_ms: MS) -> Result<i
     };
     let mut fd_set = FdSet::new();
     fd_set.insert(fd);
-    let mut dur =  Duration::from_millis(timeout_ms.into());
+    let dur = Duration::from_millis(timeout_ms.into());
     let timeout_s = dur.as_secs() as _;
     let timeout_us = dur.subsec_micros() as _;
     let mut tv = TimeVal::new(timeout_s, timeout_us);
@@ -210,4 +275,51 @@ fn wait_for_input<MS: Into<u64>>(fd: BorrowedFd<'_>, timeout_ms: MS) -> Result<i
         None,
         Some(&mut tv),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{scan_osc, OscScan};
+
+    fn found(buf: &[u8]) -> Option<&[u8]> {
+        match scan_osc(buf) {
+            OscScan::Found { start, end } => Some(&buf[start..=end]),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn bel_terminated_osc_then_fence() {
+        // ESC ] 11 ; rgb:0000/0000/0000 BEL   then DSR reply ESC [ 0 n
+        let buf = b"\x1b]11;rgb:1212/3434/5656\x07\x1b[0n";
+        let payload = found(buf).expect("should find OSC payload");
+        // payload excludes leading ESC, includes terminating BEL
+        assert_eq!(payload, b"]11;rgb:1212/3434/5656\x07");
+    }
+
+    #[test]
+    fn st_terminated_osc_then_fence() {
+        // ST = ESC \ ; the terminating ESC is the OSC end
+        let buf = b"\x1b]11;rgb:1212/3434/5656\x1b\\\x1b[0n";
+        let payload = found(buf).expect("should find OSC payload");
+        assert_eq!(payload, b"]11;rgb:1212/3434/5656\x1b");
+    }
+
+    #[test]
+    fn fence_answered_first_is_not_osc() {
+        // Terminal doesn't support the query: only the DSR reply arrives.
+        let buf = b"\x1b[0n";
+        assert!(matches!(scan_osc(buf), OscScan::NotOsc));
+    }
+
+    #[test]
+    fn incomplete_needs_more() {
+        let buf = b"\x1b]11;rgb:1212/34";
+        assert!(matches!(scan_osc(buf), OscScan::NeedMore));
+    }
+
+    #[test]
+    fn empty_needs_more() {
+        assert!(matches!(scan_osc(b""), OscScan::NeedMore));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,15 @@ mod tests {
     }
 
     #[test]
+    fn osc_payload_containing_n_is_found() {
+        // The OSC payload itself contains 'n' (e.g. `]11;none`); the scanner must
+        // not mistake that 'n' for the DSR fence and return NotOsc early.
+        let buf = b"\x1b]11;none\x07\x1b[0n";
+        let payload = found(buf).expect("OSC payload with 'n' should still be found");
+        assert_eq!(payload, b"]11;none\x07");
+    }
+
+    #[test]
     fn fence_answered_first_is_not_osc() {
         // Terminal doesn't support the query: only the DSR reply arrives.
         let buf = b"\x1b[0n";

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,0 +1,202 @@
+//! Windows backend for terminal querying.
+//!
+//! The Unix backend writes the query to stdout and reads the reply from
+//! `/dev/tty`, waiting with `poll`/`select`. On Windows the equivalent is to
+//! write the query to stdout, then read the reply from the console input
+//! (`CONIN$`) after waiting on its handle with `WaitForSingleObject`.
+//!
+//! Two Windows specifics matter:
+//! - The reply only arrives as a byte stream when the console input is in
+//!   `ENABLE_VIRTUAL_TERMINAL_INPUT` mode, so we set it (and clear line, echo,
+//!   and processed input) for the duration of the query, restoring the
+//!   previous mode on drop.
+//! - As on Unix, the caller is expected to have the terminal in raw mode and
+//!   to issue the query at a moment it isn't otherwise reading input.
+//!
+//! Limitation: `WaitForSingleObject` on the console input handle is signaled
+//! by non-character events too (focus, mouse, buffer-resize), which under
+//! VT-input mode may be delivered as escape sequences. A stray such event
+//! arriving in the query window can produce a wrong or empty reply; callers
+//! treat an unparsable reply as "unsupported" and degrade gracefully rather
+//! than hang. Filtering to key events via `ReadConsoleInputW` would harden
+//! this further.
+
+use {
+    crate::{scan_osc, OscScan, XQError},
+    std::io::{self, Write},
+    windows_sys::Win32::{
+        Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+        Storage::FileSystem::{CreateFileW, ReadFile},
+        System::{
+            Console::{GetConsoleMode, SetConsoleMode},
+            Threading::WaitForSingleObject,
+        },
+    },
+};
+
+// Stable Win32 ABI constants, defined locally to stay independent of
+// windows-sys module reorganizations between versions.
+const GENERIC_READ: u32 = 0x8000_0000;
+const GENERIC_WRITE: u32 = 0x4000_0000;
+const FILE_SHARE_READ: u32 = 0x0000_0001;
+const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+const OPEN_EXISTING: u32 = 3;
+
+const ENABLE_PROCESSED_INPUT: u32 = 0x0001;
+const ENABLE_LINE_INPUT: u32 = 0x0002;
+const ENABLE_ECHO_INPUT: u32 = 0x0004;
+const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
+
+const WAIT_OBJECT_0: u32 = 0x0000_0000;
+const WAIT_TIMEOUT: u32 = 0x0000_0102;
+
+/// A `CONIN$` handle put into VT-input mode for the duration of a query, with
+/// the previous console mode restored on drop.
+struct ConsoleInput {
+    handle: HANDLE,
+    prev_mode: u32,
+}
+
+impl ConsoleInput {
+    fn open() -> Result<Self, XQError> {
+        // "CONIN$" gives us the console input even if stdin is redirected,
+        // mirroring the Unix backend's use of /dev/tty.
+        let name: Vec<u16> = "CONIN$\0".encode_utf16().collect();
+        let handle = unsafe {
+            CreateFileW(
+                name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                core::ptr::null(),
+                OPEN_EXISTING,
+                0,
+                core::ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE || handle.is_null() {
+            return Err(XQError::IO(io::Error::last_os_error()));
+        }
+        let mut prev_mode: u32 = 0;
+        if unsafe { GetConsoleMode(handle, &mut prev_mode) } == 0 {
+            let err = io::Error::last_os_error();
+            unsafe { CloseHandle(handle) };
+            return Err(XQError::IO(err));
+        }
+        let new_mode = (prev_mode | ENABLE_VIRTUAL_TERMINAL_INPUT)
+            & !ENABLE_LINE_INPUT
+            & !ENABLE_ECHO_INPUT
+            & !ENABLE_PROCESSED_INPUT;
+        if unsafe { SetConsoleMode(handle, new_mode) } == 0 {
+            let err = io::Error::last_os_error();
+            unsafe { CloseHandle(handle) };
+            return Err(XQError::IO(err));
+        }
+        Ok(Self { handle, prev_mode })
+    }
+
+    /// Wait up to `timeout_ms` for input to be available.
+    /// Returns `Ok(true)` if input is ready, `Ok(false)` on timeout.
+    fn wait(&self, timeout_ms: u64) -> Result<bool, XQError> {
+        let ms = u32::try_from(timeout_ms).unwrap_or(u32::MAX);
+        match unsafe { WaitForSingleObject(self.handle, ms) } {
+            WAIT_OBJECT_0 => Ok(true),
+            WAIT_TIMEOUT => Ok(false),
+            _ => Err(XQError::IO(io::Error::last_os_error())),
+        }
+    }
+
+    fn read(&self, buffer: &mut [u8]) -> Result<usize, XQError> {
+        let mut read: u32 = 0;
+        let ok = unsafe {
+            ReadFile(
+                self.handle,
+                buffer.as_mut_ptr().cast(),
+                u32::try_from(buffer.len()).unwrap_or(u32::MAX),
+                &mut read,
+                core::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(XQError::IO(io::Error::last_os_error()));
+        }
+        Ok(read as usize)
+    }
+}
+
+impl Drop for ConsoleInput {
+    fn drop(&mut self) {
+        unsafe {
+            SetConsoleMode(self.handle, self.prev_mode);
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+fn write_query(query: &str) -> Result<(), XQError> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    write!(stdout, "{}", query)?;
+    stdout.flush()?;
+    Ok(())
+}
+
+/// Query the terminal, assuming it is in raw mode. Returns the number of bytes
+/// read into `buffer`.
+pub fn query_buffer<MS: Into<u64>>(
+    query: &str,
+    buffer: &mut [u8],
+    timeout_ms: MS,
+) -> Result<usize, XQError> {
+    // Put the console into VT-input mode BEFORE emitting the query: the terminal
+    // may reply within microseconds, and a reply arriving before the mode switch
+    // would not be delivered as the byte stream we read here.
+    let con = ConsoleInput::open()?;
+    write_query(query)?;
+    if con.wait(timeout_ms.into())? {
+        con.read(buffer)
+    } else {
+        Err(XQError::Timeout)
+    }
+}
+
+/// Query the terminal for an OSC response, assuming it is in raw mode.
+///
+/// Mirrors the Unix backend: the query is followed by a DSR ("fence") request
+/// so terminals that don't support the query can be detected by answering the
+/// Status Report first. The returned slice excludes the leading ESC and
+/// everything before it, and ends at (and includes) the OSC terminator.
+pub fn query_osc_buffer<'b, MS: Into<u64> + Copy>(
+    query: &str,
+    buffer: &'b mut [u8],
+    timeout_ms: MS,
+) -> Result<&'b [u8], XQError> {
+    const ESC: char = '\x1b';
+    // Switch the console into VT-input mode BEFORE emitting the query (see
+    // query_buffer), so a fast reply is captured as bytes.
+    let con = ConsoleInput::open()?;
+    // query, then the DSR fence
+    {
+        let stdout = io::stdout();
+        let mut stdout = stdout.lock();
+        write!(stdout, "{}", query)?;
+        write!(stdout, "{ESC}[5n")?;
+        stdout.flush()?;
+    }
+    let mut filled = 0;
+    while filled < buffer.len() {
+        if !con.wait(timeout_ms.into())? {
+            return Err(XQError::Timeout);
+        }
+        let bytes_read = con.read(&mut buffer[filled..])?;
+        if bytes_read == 0 {
+            return Err(XQError::NotAnOSCResponse);
+        }
+        filled += bytes_read;
+        match scan_osc(&buffer[..filled]) {
+            OscScan::Found { start, end } => return Ok(&buffer[start..=end]),
+            OscScan::NotOsc => return Err(XQError::NotAnOSCResponse),
+            OscScan::NeedMore => {}
+        }
+    }
+    Err(XQError::BufferOverflow)
+}


### PR DESCRIPTION
Implements query_buffer/query_osc_buffer on Windows by reading the reply from the console input (CONIN\$) after enabling ENABLE_VIRTUAL_TERMINAL_INPUT for the duration of the query, waiting with WaitForSingleObject. Unix code is unchanged behaviorally; the OSC scanner is factored into a shared, tested scan_osc.

Implemented for use by a separate PR (to be linked) for adding sixel support in broot including Windows terminal, hence the need for Windows OSC querying.

